### PR TITLE
Use PyJWT instead of jwt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "carconnectivity>=0.6",
     "oauthlib~=3.2.2",
     "requests~=2.32.3",
-    "jwt~=1.3.1",
+    "pyjwt~=2.10",
     "paho-mqtt~=2.1.0",
 ]
 readme = "README.md"

--- a/src/carconnectivity_connectors/skoda/auth/openid_session.py
+++ b/src/carconnectivity_connectors/skoda/auth/openid_session.py
@@ -7,7 +7,7 @@ import time
 from datetime import datetime, timezone
 import logging
 import requests
-from jwt import JWT
+import jwt
 
 from oauthlib.common import UNICODE_ASCII_CHARACTER_SET, generate_nonce, generate_token
 from oauthlib.oauth2.rfc6749.parameters import parse_authorization_code_response, parse_token_response, prepare_grant_uri
@@ -153,8 +153,7 @@ class OpenIDSession(requests.Session):
                     new_token['expires_in'] = self._token['expires_in']
                 else:
                     if 'id_token' in new_token:
-                        jwt_instance = JWT()
-                        meta_data = jwt_instance.decode(new_token['id_token'], do_verify=False)
+                        meta_data = jwt.decode(new_token['id_token'], do_verify=False)
                         if 'exp' in meta_data:
                             new_token['expires_at'] = meta_data['exp']
                             expires_at = datetime.fromtimestamp(meta_data['exp'], tz=timezone.utc)


### PR DESCRIPTION
Due to an incompatibility between these two I came across the advise to uninstall jwt and to use the better maintained PyJWT instead.

Doing this broke the CarConnectivity-connector-skoda, which I was able to modify to also use PyJWT, which I would like to suggest here.