### PR TITLE
fix: PHEV charging support for SkodaHybridVehicle

### DIFF
--- a/src/carconnectivity_connectors/skoda/connector.py
+++ b/src/carconnectivity_connectors/skoda/connector.py
@@ -411,7 +411,7 @@ class Connector(BaseConnector):
                         vehicle_to_update = self.fetch_connection_status(vehicle_to_update)
                     if vehicle_to_update.capabilities.has_capability('PARKING_POSITION', check_status_ok=True):
                         vehicle_to_update = self.fetch_position(vehicle_to_update)
-                    if vehicle_to_update.capabilities.has_capability('CHARGING', check_status_ok=True) and isinstance(vehicle_to_update, (SkodaElectricVehicle, SkodaHybridVehicle)):
+                    if vehicle_to_update.capabilities.has_capability('CHARGING', check_status_ok=True) and isinstance(vehicle_to_update, SkodaElectricVehicle):
                         vehicle_to_update = self.fetch_charging(vehicle_to_update)
                     if vehicle_to_update.capabilities.has_capability('AIR_CONDITIONING', check_status_ok=True):
                         vehicle_to_update = self.fetch_air_conditioning(vehicle_to_update)
@@ -468,12 +468,12 @@ class Connector(BaseConnector):
             if vehicle.official_connection_state is not None:
                 LOG.info('Vehicle %s went from online to %s', vehicle.vin.value, vehicle.official_connection_state.value)
 
-    def fetch_charging(self, vehicle: Union[SkodaElectricVehicle, SkodaHybridVehicle], no_cache: bool = False) -> Union[SkodaElectricVehicle, SkodaHybridVehicle]:
+    def fetch_charging(self, vehicle: SkodaElectricVehicle, no_cache: bool = False) -> SkodaElectricVehicle:
         """
-        Fetches the charging information for a given Skoda electric or hybrid vehicle.
+        Fetches the charging information for a given Skoda electric vehicle.
 
         Args:
-            vehicle (Union[SkodaElectricVehicle, SkodaHybridVehicle]): The Skoda electric or hybrid vehicle object.
+            vehicle (SkodaElectricVehicle): The Skoda electric vehicle object.
 
         Raises:
             APIError: If the VIN is missing or if the carCapturedTimestamp is missing in the response data.
@@ -1058,7 +1058,7 @@ class Connector(BaseConnector):
                 if vehicle.climatization is not None and vehicle.climatization.settings is not None:
                     # pylint: disable-next=protected-access
                     vehicle.climatization.settings.seat_heating._set_value(None, measured=captured_at)
-            if isinstance(vehicle, (SkodaElectricVehicle, SkodaHybridVehicle)):
+            if isinstance(vehicle, SkodaElectricVehicle):
                 if 'chargerConnectionState' in data and data['chargerConnectionState'] is not None \
                         and vehicle.charging is not None and vehicle.charging.connector is not None:
                     if data['chargerConnectionState'] in [item.name for item in ChargingConnector.ChargingConnectorConnectionState]:

--- a/src/carconnectivity_connectors/skoda/connector.py
+++ b/src/carconnectivity_connectors/skoda/connector.py
@@ -411,7 +411,7 @@ class Connector(BaseConnector):
                         vehicle_to_update = self.fetch_connection_status(vehicle_to_update)
                     if vehicle_to_update.capabilities.has_capability('PARKING_POSITION', check_status_ok=True):
                         vehicle_to_update = self.fetch_position(vehicle_to_update)
-                    if vehicle_to_update.capabilities.has_capability('CHARGING', check_status_ok=True) and isinstance(vehicle_to_update, SkodaElectricVehicle):
+                    if vehicle_to_update.capabilities.has_capability('CHARGING', check_status_ok=True) and isinstance(vehicle_to_update, (SkodaElectricVehicle, SkodaHybridVehicle)):
                         vehicle_to_update = self.fetch_charging(vehicle_to_update)
                     if vehicle_to_update.capabilities.has_capability('AIR_CONDITIONING', check_status_ok=True):
                         vehicle_to_update = self.fetch_air_conditioning(vehicle_to_update)
@@ -468,12 +468,12 @@ class Connector(BaseConnector):
             if vehicle.official_connection_state is not None:
                 LOG.info('Vehicle %s went from online to %s', vehicle.vin.value, vehicle.official_connection_state.value)
 
-    def fetch_charging(self, vehicle: SkodaElectricVehicle, no_cache: bool = False) -> SkodaElectricVehicle:
+    def fetch_charging(self, vehicle: Union[SkodaElectricVehicle, SkodaHybridVehicle], no_cache: bool = False) -> Union[SkodaElectricVehicle, SkodaHybridVehicle]:
         """
-        Fetches the charging information for a given Skoda electric vehicle.
+        Fetches the charging information for a given Skoda electric or hybrid vehicle.
 
         Args:
-            vehicle (SkodaElectricVehicle): The Skoda electric vehicle object.
+            vehicle (Union[SkodaElectricVehicle, SkodaHybridVehicle]): The Skoda electric or hybrid vehicle object.
 
         Raises:
             APIError: If the VIN is missing or if the carCapturedTimestamp is missing in the response data.
@@ -1058,7 +1058,7 @@ class Connector(BaseConnector):
                 if vehicle.climatization is not None and vehicle.climatization.settings is not None:
                     # pylint: disable-next=protected-access
                     vehicle.climatization.settings.seat_heating._set_value(None, measured=captured_at)
-            if isinstance(vehicle, SkodaElectricVehicle):
+            if isinstance(vehicle, (SkodaElectricVehicle, SkodaHybridVehicle)):
                 if 'chargerConnectionState' in data and data['chargerConnectionState'] is not None \
                         and vehicle.charging is not None and vehicle.charging.connector is not None:
                     if data['chargerConnectionState'] in [item.name for item in ChargingConnector.ChargingConnectorConnectionState]:

--- a/src/carconnectivity_connectors/skoda/vehicle.py
+++ b/src/carconnectivity_connectors/skoda/vehicle.py
@@ -101,7 +101,7 @@ class SkodaCombustionVehicle(CombustionVehicle, SkodaVehicle):
             super().__init__(vin=vin, garage=garage, managing_connector=managing_connector, initialization=initialization)
 
 
-class SkodaHybridVehicle(HybridVehicle, SkodaVehicle):
+class SkodaHybridVehicle(HybridVehicle, SkodaElectricVehicle, SkodaCombustionVehicle):
     """
     Represents a Skoda hybrid vehicle.
     """
@@ -109,10 +109,5 @@ class SkodaHybridVehicle(HybridVehicle, SkodaVehicle):
                  origin: Optional[SkodaVehicle] = None, initialization: Optional[Dict] = None) -> None:
         if origin is not None:
             super().__init__(garage=garage, origin=origin, initialization=initialization)
-            if isinstance(origin, ElectricVehicle):
-                self.charging: Charging = SkodaCharging(vehicle=self, origin=origin.charging)
-            else:
-                self.charging: Charging = SkodaCharging(vehicle=self, origin=self.charging)
         else:
             super().__init__(vin=vin, garage=garage, managing_connector=managing_connector, initialization=initialization)
-            self.charging: Charging = SkodaCharging(vehicle=self, origin=self.charging, initialization=self.get_initialization('charging'))

--- a/src/carconnectivity_connectors/skoda/vehicle.py
+++ b/src/carconnectivity_connectors/skoda/vehicle.py
@@ -109,5 +109,10 @@ class SkodaHybridVehicle(HybridVehicle, SkodaVehicle):
                  origin: Optional[SkodaVehicle] = None, initialization: Optional[Dict] = None) -> None:
         if origin is not None:
             super().__init__(garage=garage, origin=origin, initialization=initialization)
+            if isinstance(origin, ElectricVehicle):
+                self.charging: Charging = SkodaCharging(vehicle=self, origin=origin.charging)
+            else:
+                self.charging: Charging = SkodaCharging(vehicle=self, origin=self.charging)
         else:
             super().__init__(vin=vin, garage=garage, managing_connector=managing_connector, initialization=initialization)
+            self.charging: Charging = SkodaCharging(vehicle=self, origin=self.charging, initialization=self.get_initialization('charging'))


### PR DESCRIPTION
- Extend isinstance check in update_vehicles() to include SkodaHybridVehicle so fetch_charging() is called for PHEV vehicles with CHARGING capability
- Update fetch_charging() type signature to accept Union[SkodaElectricVehicle, SkodaHybridVehicle]
- Extend isinstance check in fetch_air_conditioning() for chargerConnectionState and chargerLockState handling to include SkodaHybridVehicle
- Add SkodaCharging object to SkodaHybridVehicle (analogous to SkodaElectricVehicle) so PHEV vehicles have Skoda-specific charging fields (preferred_charge_mode, charging_care_mode, battery_support, is_in_saved_location, etc.)